### PR TITLE
Fixes #24: Use the default layout, when there is no meta field for a route

### DIFF
--- a/vue-extend-layout.vue
+++ b/vue-extend-layout.vue
@@ -32,9 +32,10 @@ export default {
   },
 
   watch: {
-    '$route.meta.layout': {
+    '$route': {
       immediate: true,
-      handler (newLayout) {
+      handler (route) {
+        const newLayout = route.meta.layout
         if (!newLayout && !this.$route.name) { this.layoutName = this.loading; return }
         if (!newLayout) { this.layoutName = this.layout || 'default'; return }
         this.layoutName = newLayout


### PR DESCRIPTION
`$route.meta.layout` might be undefined in some cases. This results in the loading layout being rendered on page refresh or when opening a deep link. This happens only in hash mode.